### PR TITLE
Examples: Grids for spatially resolved quantities

### DIFF
--- a/docs/examples/chain.py
+++ b/docs/examples/chain.py
@@ -30,7 +30,7 @@ ez[~valid] = np.nan
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 0], ez.T, shading="nearest", vmin=-0.5, vmax=0.5,
+    grid[:, 0, 0], grid[0, :, 2], ez.T, shading="nearest", vmin=-0.5, vmax=0.5,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("$E_z$")

--- a/docs/examples/chain.py
+++ b/docs/examples/chain.py
@@ -17,8 +17,14 @@ chain = treams.TMatrix.cluster(spheres, positions).latticeinteraction.solve(latt
 inc = treams.plane_wave([k0, 0, 0], [0, 0, 1], k0=chain.k0, material=chain.material)
 sca = chain @ inc.expand(chain.basis)
 
-grid = np.mgrid[-150:150:31j, 0:1, -150:150:31j].squeeze().transpose((1, 2, 0))
-ez = np.zeros_like(grid[..., 0])
+x = np.linspace(-150, 150, 31)
+y = 0
+z = np.linspace(-150, 150, 31)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+ez = np.zeros_like(xx)
 valid = chain.valid_points(grid, radii)
 vals = []
 for i, r in enumerate(grid[valid]):
@@ -30,7 +36,7 @@ ez[~valid] = np.nan
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 2], ez.T, shading="nearest", vmin=-0.5, vmax=0.5,
+    xx, zz, ez, shading="nearest", vmin=-0.5, vmax=0.5,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("$E_z$")

--- a/docs/examples/chain_tmatrixc.py
+++ b/docs/examples/chain_tmatrixc.py
@@ -26,10 +26,14 @@ inc = treams.plane_wave(
 )
 sca = chain_tmc @ inc.expand(chain_tmc.basis)
 
-grid = (
-    np.mgrid[-300:300:61j, 0:1, -150:150:31j].squeeze().transpose((1, 2, 0))[:, :-1, :]
-)
-ez = np.zeros_like(grid[..., 0], complex)
+x = np.linspace(-300, 300, 61)
+y = 0
+z = np.linspace(-150, 150, 31)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+ez = np.zeros_like(xx, complex)
 valid = chain_tmc.valid_points(grid, radii)
 ez[valid] = (inc.efield(grid[valid]) + sca.efield(grid[valid]))[..., 2]
 ez[~valid] = np.nan
@@ -44,15 +48,17 @@ ez[valid] = vals
 
 ez = np.concatenate(
     (
-        np.real(ez.T * np.exp(-1j * kz * lattice[...])),
-        ez.T.real,
-        np.real(ez.T * np.exp(1j * kz * lattice[...])),
-    )
+        np.real(ez * np.exp(-1j * kz * lattice[...])),
+        ez.real,
+        np.real(ez * np.exp(1j * kz * lattice[...])),
+    ),
+    axis=1,
 )
-zaxis = np.concatenate((grid[0, :, 2] - 300, grid[0, :, 2], grid[0, :, 2] + 300,))
+xx = np.tile(xx, (1, 3))
+zz = np.concatenate((zz - lattice[...], zz, zz + lattice[...]), axis=1)
 
 fig, ax = plt.subplots(figsize=(10, 20))
-pcm = ax.pcolormesh(grid[:, 0, 0], zaxis, ez, shading="nearest", vmin=-1, vmax=1,)
+pcm = ax.pcolormesh(xx, zz, ez, shading="nearest", vmin=-1, vmax=1,)
 cb = plt.colorbar(pcm)
 cb.set_label("$E_z$")
 ax.set_xlabel("x (nm)")

--- a/docs/examples/cluster.py
+++ b/docs/examples/cluster.py
@@ -33,7 +33,7 @@ intensity[valid] = 0.5 * np.sum(
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 0], intensity.T, shading="nearest", vmin=0, vmax=2,
+    grid[:, 0, 0], grid[0, :, 2], intensity.T, shading="nearest", vmin=0, vmax=2,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")
@@ -64,7 +64,7 @@ intensity_global[valid] = 0.5 * np.sum(
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 0], intensity_global.T, shading="nearest", vmin=0, vmax=2,
+    grid[:, 0, 0], grid[0, :, 2], intensity_global.T, shading="nearest", vmin=0, vmax=2,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")
@@ -96,7 +96,7 @@ intensity_global[valid] = 0.5 * np.sum(
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 0], intensity_global.T, shading="nearest", vmin=0, vmax=2,
+    grid[:, 0, 0], grid[0, :, 2], intensity_global.T, shading="nearest", vmin=0, vmax=2,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")

--- a/docs/examples/cluster.py
+++ b/docs/examples/cluster.py
@@ -23,8 +23,14 @@ inc = treams.plane_wave([k0, 0, 0], 0, k0=tm.k0, material=tm.material)
 sca = tm @ inc.expand(tm.basis)
 xs = tm.xs(inc)
 
-grid = np.mgrid[-300:300:101j, 0:1, -300:300:101j].squeeze().transpose((1, 2, 0))
-intensity = np.zeros_like(grid[..., 0])
+x = np.linspace(-300, 300, 101)
+y = 0
+z = np.linspace(-300, 300, 101)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+intensity = np.zeros_like(xx)
 valid = tm.valid_points(grid, radii)
 intensity[~valid] = np.nan
 intensity[valid] = 0.5 * np.sum(
@@ -33,7 +39,7 @@ intensity[valid] = 0.5 * np.sum(
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 2], intensity.T, shading="nearest", vmin=0, vmax=2,
+    xx, zz, intensity, shading="nearest", vmin=0, vmax=2,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")
@@ -54,8 +60,14 @@ sca = tm_global @ inc.expand(tm_global.basis)
 
 xs = tm_global.xs(inc)
 
-grid = np.mgrid[-300:300:101j, 0:1, -300:300:101j].squeeze().transpose((1, 2, 0))
-intensity_global = np.zeros_like(grid[..., 0])
+x = np.linspace(-300, 300, 101)
+y = 0
+z = np.linspace(-300, 300, 101)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+intensity_global = np.zeros_like(xx)
 valid = tm_global.valid_points(grid, [260])
 intensity_global[~valid] = np.nan
 intensity_global[valid] = 0.5 * np.sum(
@@ -64,7 +76,7 @@ intensity_global[valid] = 0.5 * np.sum(
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 2], intensity_global.T, shading="nearest", vmin=0, vmax=2,
+    xx, zz, intensity_global, shading="nearest", vmin=0, vmax=2,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")
@@ -86,8 +98,14 @@ sca = tm_rotate @ inc.expand(tm_rotate.basis)
 
 xs = tm_rotate.xs(inc)
 
-grid = np.mgrid[-300:300:101j, 0:1, -300:300:101j].squeeze().transpose((1, 2, 0))
-intensity_global = np.zeros_like(grid[..., 0])
+x = np.linspace(-300, 300, 101)
+y = 0
+z = np.linspace(-300, 300, 101)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+intensity_global = np.zeros_like(xx)
 valid = tm_rotate.valid_points(grid, [260])
 intensity_global[~valid] = np.nan
 intensity_global[valid] = 0.5 * np.sum(
@@ -96,7 +114,7 @@ intensity_global[valid] = 0.5 * np.sum(
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 2], intensity_global.T, shading="nearest", vmin=0, vmax=2,
+    xx, zz, intensity_global, shading="nearest", vmin=0, vmax=2,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")

--- a/docs/examples/cylinder_tmatrixc.py
+++ b/docs/examples/cylinder_tmatrixc.py
@@ -41,7 +41,7 @@ fig.show()
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 1], grid[:, 0, 0], intensity.T, shading="nearest", vmin=0, vmax=1,
+    grid[:, 0, 0], grid[0, :, 1], intensity.T, shading="nearest", vmin=0, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")

--- a/docs/examples/cylinder_tmatrixc.py
+++ b/docs/examples/cylinder_tmatrixc.py
@@ -21,8 +21,15 @@ xw_ext_mmax0 = np.array([tm.xw_ext_avg for tm in cylinders_mmax0]) / (2 * radius
 tm = cylinders[-1]
 inc = treams.plane_wave([tm.k0, 0, 0], 1, k0=tm.k0, material=tm.material)
 sca = tm @ inc.expand(tm.basis)
-grid = np.mgrid[-100:100:101j, -100:100:101j, 0:1].squeeze().transpose((1, 2, 0))
-intensity = np.zeros_like(grid[..., 0])
+
+x = np.linspace(-100, 100, 101)
+y = np.linspace(-100, 100, 101)
+z = 0
+xx, yy = np.meshgrid(x, y, indexing="ij")
+zz = np.full_like(xx, z)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+intensity = np.zeros_like(xx)
 valid = tm.valid_points(grid, [radius])
 intensity[~valid] = np.nan
 intensity[valid] = 0.5 * np.sum(
@@ -41,7 +48,7 @@ fig.show()
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 1], intensity.T, shading="nearest", vmin=0, vmax=1,
+    xx, yy, intensity, shading="nearest", vmin=0, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")

--- a/docs/examples/grating_tmatrixc.py
+++ b/docs/examples/grating_tmatrixc.py
@@ -45,7 +45,7 @@ ex[~valid] = np.nan
 
 fig, ax = plt.subplots(figsize=(10, 20))
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 1], ex.T, shading="nearest", vmin=-1, vmax=1,
+    grid[:, 0, 1], grid[0, :, 2], ex.T, shading="nearest", vmin=-1, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("$E_x$")

--- a/docs/examples/grating_tmatrixc.py
+++ b/docs/examples/grating_tmatrixc.py
@@ -31,8 +31,14 @@ inc = treams.plane_wave(
 )
 sca = cluster @ inc.expand(cluster.basis)
 
-grid = np.mgrid[0:1, -150:150:16j, -150:150:16j].squeeze().transpose((1, 2, 0))
-ex = np.zeros_like(grid[..., 0])
+x = 0
+y = np.linspace(-150, 150, 16)
+z = np.linspace(-150, 150, 16)
+yy, zz = np.meshgrid(y, z, indexing="ij")
+xx = np.full_like(yy, x)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+ex = np.zeros_like(xx)
 valid = cluster.valid_points(grid, radii)
 vals = []
 for i, r in enumerate(grid[valid]):
@@ -42,10 +48,9 @@ for i, r in enumerate(grid[valid]):
 ex[valid] = vals
 ex[~valid] = np.nan
 
-
 fig, ax = plt.subplots(figsize=(10, 20))
 pcm = ax.pcolormesh(
-    grid[:, 0, 1], grid[0, :, 2], ex.T, shading="nearest", vmin=-1, vmax=1,
+    yy, zz, ex, shading="nearest", vmin=-1, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("$E_x$")

--- a/docs/examples/grid.py
+++ b/docs/examples/grid.py
@@ -32,7 +32,7 @@ ez[~valid] = np.nan
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 0], ez.T, shading="nearest", vmin=-1, vmax=1,
+    grid[:, 0, 0], grid[0, :, 2], ez.T, shading="nearest", vmin=-1, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("$E_z$")

--- a/docs/examples/grid.py
+++ b/docs/examples/grid.py
@@ -19,8 +19,14 @@ array = treams.TMatrix.cluster(spheres, positions).latticeinteraction.solve(
 inc = treams.plane_wave([0, 0, k0], [-1, 0, 0], k0=array.k0, material=array.material)
 sca = array @ inc.expand(array.basis)
 
-grid = np.mgrid[-150:150:31j, 0:1, -150:150:31j].squeeze().transpose((1, 2, 0))
-ez = np.zeros_like(grid[..., 0])
+x = np.linspace(-150, 150, 31)
+y = 0
+z = np.linspace(-150, 150, 31)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+ez = np.zeros_like(xx)
 valid = array.valid_points(grid, radii)
 vals = []
 for i, r in enumerate(grid[valid]):
@@ -32,7 +38,7 @@ ez[~valid] = np.nan
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 2], ez.T, shading="nearest", vmin=-1, vmax=1,
+    xx, zz, ez, shading="nearest", vmin=-1, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("$E_z$")

--- a/docs/examples/sphere.py
+++ b/docs/examples/sphere.py
@@ -20,8 +20,15 @@ xs_ext_lmax1 = np.array([tm.xs_ext_avg for tm in spheres_lmax1]) / (np.pi * radi
 tm = spheres[-1]
 inc = treams.plane_wave([0, 0, tm.k0], 1, k0=tm.k0, material=tm.material)
 sca = tm @ inc.expand(tm.basis)
-grid = np.mgrid[-100:100:101j, 0:1, -100:100:101j].squeeze().transpose((1, 2, 0))
-intensity = np.zeros_like(grid[..., 0])
+
+x = np.linspace(-100, 100, 101)
+y = 0
+z = np.linspace(-100, 100, 101)
+xx, zz = np.meshgrid(x, z, indexing="ij")
+yy = np.full_like(xx, y)
+grid = np.stack((xx, yy, zz), axis=-1)
+
+intensity = np.zeros_like(xx)
 valid = tm.valid_points(grid, [radius])
 intensity[~valid] = np.nan
 intensity[valid] = 0.5 * np.sum(
@@ -40,7 +47,7 @@ fig.show()
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[:, 0, 0], grid[0, :, 2], intensity.T, shading="nearest", vmin=0, vmax=1,
+    xx, zz, intensity, shading="nearest", vmin=0, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")

--- a/docs/examples/sphere.py
+++ b/docs/examples/sphere.py
@@ -40,7 +40,7 @@ fig.show()
 
 fig, ax = plt.subplots()
 pcm = ax.pcolormesh(
-    grid[0, :, 2], grid[:, 0, 0], intensity.T, shading="nearest", vmin=0, vmax=1,
+    grid[:, 0, 0], grid[0, :, 2], intensity.T, shading="nearest", vmin=0, vmax=1,
 )
 cb = plt.colorbar(pcm)
 cb.set_label("Intensity")

--- a/docs/tmatrix.rst
+++ b/docs/tmatrix.rst
@@ -59,7 +59,7 @@ we visualize the fields at the largest frequency.
 
 .. literalinclude:: examples/sphere.py
    :language: python
-   :lines: 20-29
+   :lines: 20-36
 
 We select the T-matrix and illuminate it with a plane wave. Next, we set up the grid
 and choose valid points, namely those that are outside of our spherical object. Then,
@@ -98,7 +98,7 @@ sphere we can obtain the fields outside of the sphere
 
 .. literalinclude:: examples/cluster.py
    :language: python
-   :lines: 26-32
+   :lines: 26-38
 
 Up to here, we did all calculations for the cluster in the local basis. By expanding
 the incident and scattered fields in a basis with a single origin we can describe the
@@ -108,7 +108,7 @@ basis can be more efficient in terms of matrix size.
 
 .. literalinclude:: examples/cluster.py
    :language: python
-   :lines: 57-68
+   :lines: 58-75
 
 A comparison of the calculated near-fields and the cross sections show good agreement
 between the results of both, local and global, T-matrices.
@@ -122,7 +122,7 @@ operator produces consistent results.
 
 .. literalinclude:: examples/cluster.py
    :language: python
-   :lines: 83-95
+   :lines: 95-113
 
 
 One-dimensional arrays (along z)
@@ -162,7 +162,7 @@ we want to probe.
 
 .. literalinclude:: examples/chain.py
    :language: python
-   :lines: 20-29
+   :lines: 20-35
 
 Here, we plot the z-component of the electric field. Note, that the values at the top
 and bottom side match exactly, as required due to the periodic boundary conditions.
@@ -178,7 +178,7 @@ x-y-plane.
 
 .. literalinclude:: examples/grid.py
    :language: python
-   :lines: 6-31
+   :lines: 6-37
 
 With few changes we get the fields in a square array of the same spheres as in the
 previous examples. Most importantly we changed the value of the variable :code:`lattice`

--- a/docs/tmatrix.rst
+++ b/docs/tmatrix.rst
@@ -122,7 +122,7 @@ operator produces consistent results.
 
 .. literalinclude:: examples/cluster.py
    :language: python
-   :lines: 94-106
+   :lines: 83-95
 
 
 One-dimensional arrays (along z)

--- a/docs/tmatrixc.rst
+++ b/docs/tmatrixc.rst
@@ -46,7 +46,7 @@ by
 
 .. literalinclude:: examples/cylinder_tmatrixc.py
     :language: python
-    :lines: 13-15
+    :lines: 13-14
 
 Again, we can also select specific modes only, for example the modes with :math:`m = 0`.
 
@@ -59,7 +59,7 @@ equally simple.
 
 .. literalinclude:: examples/cylinder_tmatrixc.py
     :language: python
-    :lines: 16-19
+    :lines: 21-37
 
 .. plot:: examples/cylinder_tmatrixc.py
 
@@ -163,7 +163,7 @@ area
 
 .. literalinclude:: examples/grating_tmatrixc.py
     :language: python
-    :lines: 34-43
+    :lines: 34-49
 
 and plot the results.
 


### PR DESCRIPTION
- Fixes the order of the coordinate axes in all example scripts involving colorplots.
- Improves readability by using `np.meshgrid` plus explicit ranges for the coordinates over the previously used `np.mgrid` in the evaluation of spatially resolved quantities.
