### PR TITLE
TYPO: Fix parameter order in propagation method documentation

### DIFF
--- a/src/treams/_smatrix.py
+++ b/src/treams/_smatrix.py
@@ -284,8 +284,8 @@ class SMatrices:
 
         Args:
             r (float, (3,)-array): Translation vector.
-            k0 (float): Wave number in vacuum.
             basis (PlaneWaveBasis): Basis definition.
+            k0 (float): Wave number in vacuum.
             material (Material, optional): Material definition.
             poltype (str, optional): Polarization type (:ref:`params:Polarizations`).
 


### PR DESCRIPTION
## Description

This PR fixes a documentation error in the `propagation` method of the `SMatrix` class in `src/treams/_smatrix.py`.

## Problem

The docstring for the `propagation` method had the wrong parameter order in the Args section. It listed:
1. r
2. k0
3. basis

But the actual function signature is:
```python
def propagation(cls, r, basis, k0, material=Material(), poltype=None):
```

## Solution

Updated the documentation to match the correct parameter order:
1. r (Translation vector)
2. basis (PlaneWaveBasis)
3. k0 (Wave number in vacuum)
4. material (Material, optional)
5. poltype (str, optional)

## Changes Made

- Fixed the Args section in the docstring to reflect the correct parameter order
- No functional code changes, only documentation correction
