### PR TITLE
Polarization Matching for the Expansion of Planewaves in Planewavebasis

### DIFF
--- a/src/treams/_operators.py
+++ b/src/treams/_operators.py
@@ -634,7 +634,8 @@ def _pw_pw_expand(basis, to_basis, k0, material, modetype, where):
         where
         & (kx[:, None] == kvecs[0])
         & (ky[:, None] == kvecs[1])
-        & (kz[:, None] == kvecs[2]),
+        & (kz[:, None] == kvecs[2])
+        & (to_basis.pol[:, None] == basis.pol),
         int,
     )
     return core.PhysicsArray(

--- a/src/treams/util.py
+++ b/src/treams/util.py
@@ -567,7 +567,7 @@ class AnnotatedArray(np.lib.mixins.NDArrayOperatorsMixin):
     def __complex__(self):
         return complex(self._array)
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Convert to an numpy array.
 
         This function returns the bare array without annotations. This function does not


### PR DESCRIPTION
To address issues coming up by expanding a plane wave into a plane wave basis, the matching of the polarizations has been added. Additionally the override of the array function has been modified according to the migration guide of numpy.