### PR TITLE
FIX: NameError: name 'long' is not defined 

### DIFF
--- a/src/treams/lattice/_misc.pyx
+++ b/src/treams/lattice/_misc.pyx
@@ -216,7 +216,7 @@ def cube(long d, long n):
     cdef long r[3]
     cdef long[:] rview = r
     cdef long i = 0
-    cdef np.ndarray[long, ndim=2] res = np.empty((ncube(d, n), d), dtype=long)
+    cdef np.ndarray[long, ndim=2] res = np.empty((ncube(d, n), d), dtype=int)
     for i in range(3):
         r[i] = -n
     res[0, :] = rview[:d]
@@ -247,7 +247,7 @@ def cubeedge(long d, long n):
     cdef long r[3]
     cdef long[:] rview = r
     cdef long i = 0
-    cdef np.ndarray[long, ndim=2] res = np.empty((nedge(d, n), d), dtype=long)
+    cdef np.ndarray[long, ndim=2] res = np.empty((nedge(d, n), d), dtype=int)
     for i in range(3):
         r[i] = -n
     res[0, :] = rview[:d]


### PR DESCRIPTION
The long type has become a synonym to int in the new python versions, and was therefore changed in the code, to fix the NameError that occurred during the unit tests.