### PR TITLE
FIX: copy keyword changes of ndarrays

### DIFF
--- a/src/treams/util.py
+++ b/src/treams/util.py
@@ -567,7 +567,7 @@ class AnnotatedArray(np.lib.mixins.NDArrayOperatorsMixin):
     def __complex__(self):
         return complex(self._array)
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Convert to an numpy array.
 
         This function returns the bare array without annotations. This function does not


### PR DESCRIPTION
The change to the override function were made accordingly to the migration guide found here:
https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword