### PR TITLE
FIX: fixing the build process by updating the artifact handler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       #   if: ${{ github.event_name == 'workflow_dispatch' }}
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
       - name: Build sdist
         run: pipx run build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -64,7 +64,7 @@ jobs:
     if: success() || failure()
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Use Twine to Publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
Using the new versions (v4) of download-artifact and upload-artifact, to fix the build process and make the new treams version available to install via pip.