### PR TITLE
Build with v4 for python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
       #   if: ${{ github.event_name == 'workflow_dispatch' }}
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        uses: pypa/cibuildwheel@v4.1.0
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       #   if: ${{ github.event_name == 'workflow_dispatch' }}
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21.3
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
       - name: Build sdist
         run: pipx run build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -64,7 +64,7 @@ jobs:
     if: success() || failure()
     steps:
       - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Use Twine to Publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
For some reason the wheels for h5py are broken on the linux machine with python 3.10.
This is an attempt to fix this by using a newer version of the project that handles the building of the wheels.